### PR TITLE
Fix cs checks

### DIFF
--- a/src/Factory/DefaultAuthorizationListenerFactory.php
+++ b/src/Factory/DefaultAuthorizationListenerFactory.php
@@ -41,11 +41,9 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
             ));
         }
 
-        if ($container->has(AuthorizationInterface::class)) {
-            $authorization = $container->get(AuthorizationInterface::class);
-        } else {
-            $authorization = $container->get(\ZF\MvcAuth\Authorization\AuthorizationInterface::class);
-        }
+        $authorization = $container->has(AuthorizationInterface::class)
+            ? $container->get(AuthorizationInterface::class)
+            : $container->get(\ZF\MvcAuth\Authorization\AuthorizationInterface::class);
 
         return new DefaultAuthorizationListener($authorization);
     }

--- a/src/Factory/DefaultAuthorizationListenerFactory.php
+++ b/src/Factory/DefaultAuthorizationListenerFactory.php
@@ -26,7 +26,7 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
      * @param ContainerInterface $container
      * @param string             $requestedName
      * @param null|array         $options
-     * @return DefaultAuthorizationListenerFactory
+     * @return DefaultAuthorizationListener
      * @throws ServiceNotCreatedException if the AuthorizationInterface service is missing.
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
@@ -41,7 +41,13 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
             ));
         }
 
-        return new DefaultAuthorizationListener($container->has(AuthorizationInterface::class) ? $container->get(AuthorizationInterface::class) : $container->get(\ZF\MvcAuth\Authorization\AuthorizationInterface::class));
+        if ($container->has(AuthorizationInterface::class)) {
+            $authorization = $container->get(AuthorizationInterface::class);
+        } else {
+            $authorization = $container->get(\ZF\MvcAuth\Authorization\AuthorizationInterface::class);
+        }
+
+        return new DefaultAuthorizationListener($authorization);
     }
 
     /**
@@ -50,7 +56,7 @@ class DefaultAuthorizationListenerFactory implements FactoryInterface
      * Provided for backwards compatibility; proxies to __invoke().
      *
      * @param ServiceLocatorInterface $container
-     * @return DefaultAuthorizationListenerFactory
+     * @return DefaultAuthorizationListener
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/test/Authorization/AclAuthorizationFactoryTest.php
+++ b/test/Authorization/AclAuthorizationFactoryTest.php
@@ -37,7 +37,9 @@ class AclAuthorizationFactoryTest extends TestCase
         $acl->addRole('authenticated');
 
         // Test access to a collection that has ACLs in place
-        $this->assertTrue($acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST'));
+        $this->assertTrue(
+            $acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST')
+        );
         $this->assertFalse($acl->isAllowed('guest', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST'));
         $this->assertTrue($acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'GET'));
         $this->assertTrue($acl->isAllowed('guest', 'LaminasCon\V1\Rest\Session\Controller::collection', 'GET'));
@@ -84,7 +86,9 @@ class AclAuthorizationFactoryTest extends TestCase
         $acl->addRole('authenticated');
 
         // Test access to a collection that has ACLs in place
-        $this->assertTrue($acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST'));
+        $this->assertTrue(
+            $acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST')
+        );
         $this->assertTrue($acl->isAllowed('authenticated', 'LaminasCon\V1\Rest\Session\Controller::collection', 'GET'));
         $this->assertFalse($acl->isAllowed('guest', 'LaminasCon\V1\Rest\Session\Controller::collection', 'POST'));
         $this->assertTrue($acl->isAllowed('guest', 'LaminasCon\V1\Rest\Session\Controller::collection', 'GET'));

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -43,7 +43,8 @@ class DefaultResourceResolverListenerTest extends TestCase
     public function createMvcAuthEvent(MvcEvent $mvcEvent)
     {
         $this->authentication = new TestAsset\AuthenticationService();
-        $this->authorization  = $this->getMockBuilder('Laminas\ApiTools\MvcAuth\Authorization\AuthorizationInterface')->getMock();
+        $this->authorization  = $this->getMockBuilder('Laminas\ApiTools\MvcAuth\Authorization\AuthorizationInterface')
+            ->getMock();
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fixes long line causing cs-check fail

Also corrects `DefaultAuthorizationListenerFactory` docblock return