### PR TITLE
Add Psalm integration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,5 +31,3 @@ jobs:
         uses: laminas/laminas-continuous-integration-action@v1
         with:
           job: ${{ matrix.job }}
-        env:
-          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_READ_ONLY_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,9 @@
         "laminas/laminas-coding-standard": "~2.2.0",
         "laminas/laminas-session": "^2.8.5",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.3",
+        "psalm/plugin-phpunit": "^0.16.0",
+        "vimeo/psalm": "^4.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11a5aaed80c7545458853aa2cbfaf831",
+    "content-hash": "cc637964f6cea279b6787d7badab3cca",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -2085,6 +2085,390 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-10T17:06:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "reference": "c6522afe5540d5fc46675043d3ed5a45a740b27c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T07:46:03+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "reference": "31f3ea725711245195f62e54ffa402d8ef2fdba9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-24T12:41:47+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "reference": "964adcdd3a28bf9ed5d9ac6450064e0d71ed7496",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-05T19:37:51+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",
             "source": {
@@ -2155,6 +2539,43 @@
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -2222,6 +2643,107 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+            },
+            "time": "2021-01-10T17:48:47+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -2415,6 +2937,110 @@
                 }
             ],
             "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -3277,6 +3903,116 @@
                 }
             ],
             "time": "2021-06-05T04:49:07+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "1ce1ef2c3fe8bed6ddaba1607c00b48a52145023"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/1ce1ef2c3fe8bed6ddaba1607c00b48a52145023",
+                "reference": "1ce1ef2c3fe8bed6ddaba1607c00b48a52145023",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.5"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.16.0"
+            },
+            "time": "2021-06-06T07:53:56+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4360,6 +5096,171 @@
             "time": "2021-04-09T00:54:41+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/058553870f7809087fa80fa734704a21b9bcaeb2",
+                "reference": "058553870f7809087fa80fa734704a21b9bcaeb2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.23.0",
             "source": {
@@ -4439,6 +5340,575 @@
             "time": "2021-02-19T12:13:01+00:00"
         },
         {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.1"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-01T10:43:52+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "reference": "a9a0f8b6aafc5d2d1c116dcccd1573a95153515b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-26T17:43:10+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -4487,6 +5957,111 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "vimeo/psalm",
+            "version": "4.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "38c452ae584467e939d55377aaf83b5a26f19dd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/38c452ae584467e939d55377aaf83b5a26f19dd1",
+                "reference": "38c452ae584467e939d55377aaf83b5a26f19dd1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1 || ^2.0",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.5",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.7.3"
+            },
+            "time": "2021-05-24T04:09:51+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4600,6 +6175,56 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
             "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,1278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.7.3@38c452ae584467e939d55377aaf83b5a26f19dd1">
+  <file src="config/module.config.php">
+    <UndefinedClass occurrences="1">
+      <code>Authentication\AuthHttpAdapter</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Authentication/AbstractAdapter.php">
+    <MixedArgument occurrences="1">
+      <code>$authorization-&gt;getFieldValue()</code>
+    </MixedArgument>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>getFieldValue</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>getFieldValue</code>
+    </PossiblyUndefinedMethod>
+    <UnusedVariable occurrences="1">
+      <code>$credential</code>
+    </UnusedVariable>
+  </file>
+  <file src="src/Authentication/DefaultAuthenticationListener.php">
+    <ArgumentTypeCoercion occurrences="2">
+      <code>$response</code>
+      <code>$response</code>
+    </ArgumentTypeCoercion>
+    <DeprecatedMethod occurrences="1">
+      <code>attachHttpAdapter</code>
+    </DeprecatedMethod>
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;httpAdapter</code>
+      <code>$this-&gt;httpAdapter</code>
+    </DeprecatedProperty>
+    <MixedArgument occurrences="1">
+      <code>$mvcAuthEvent-&gt;getAuthenticationService()</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>string|false</code>
+    </MixedInferredReturnType>
+    <UndefinedDocblockClass occurrences="1">
+      <code>null|V2RouteMatch|RouteMatch</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Authentication/DefaultAuthenticationPostListener.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$response</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>null|HttpResponse</code>
+    </MoreSpecificReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>isValid</code>
+    </PossiblyNullReference>
+  </file>
+  <file src="src/Authentication/HttpAdapter.php">
+    <MixedArgument occurrences="2">
+      <code>$name</code>
+      <code>$resultIdentity</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$name</code>
+      <code>$name</code>
+      <code>$resultIdentity</code>
+    </MixedAssignment>
+    <TooManyArguments occurrences="1">
+      <code>authenticate</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Authentication/OAuth2Adapter.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>Identity\AuthenticatedIdentity|Identity\GuestIdentity|Response</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedArgument occurrences="11">
+      <code>$oauth2Response</code>
+      <code>$oauth2Response-&gt;getHttpHeaders()</code>
+      <code>$request-&gt;getContent()</code>
+      <code>$request-&gt;getFiles() ? $request-&gt;getFiles()-&gt;toArray() : []</code>
+      <code>$request-&gt;getHeaders()-&gt;toArray()</code>
+      <code>$request-&gt;getPost()-&gt;toArray()</code>
+      <code>$request-&gt;getQuery()-&gt;toArray()</code>
+      <code>$token</code>
+      <code>$token['user_id']</code>
+      <code>$value</code>
+      <code>method_exists($request, 'getServer') ? $request-&gt;getServer()-&gt;toArray() : $_SERVER</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$header</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$token['user_id']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="4">
+      <code>$oauth2Response</code>
+      <code>$status</code>
+      <code>$token</code>
+      <code>$value</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="8">
+      <code>getHttpHeaders</code>
+      <code>getParameter</code>
+      <code>getStatusCode</code>
+      <code>match</code>
+      <code>toArray</code>
+      <code>toArray</code>
+      <code>toArray</code>
+      <code>toArray</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="4">
+      <code>get</code>
+      <code>getArrayCopy</code>
+      <code>has</code>
+      <code>toArray</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>get</code>
+      <code>has</code>
+      <code>toArray</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/Authorization/AclAuthorization.php">
+    <MixedArgument occurrences="4">
+      <code>$privilege</code>
+      <code>$resource</code>
+      <code>$resource</code>
+      <code>$resource</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Authorization/AclAuthorizationFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$ruleSet['resource']</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$privileges</code>
+      <code>$resource</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Authorization/DefaultAuthorizationListener.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>bool</code>
+    </MixedInferredReturnType>
+    <UndefinedClass occurrences="1">
+      <code>V2RouteMatch</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Authorization/DefaultAuthorizationPostListener.php">
+    <LessSpecificReturnStatement occurrences="1">
+      <code>$response</code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType occurrences="1">
+      <code>null|HttpResponse</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="src/Authorization/DefaultResourceResolverListener.php">
+    <MixedInferredReturnType occurrences="1">
+      <code>false|string</code>
+    </MixedInferredReturnType>
+    <PossiblyNullArgument occurrences="1">
+      <code>$routeMatch</code>
+    </PossiblyNullArgument>
+    <UndefinedDocblockClass occurrences="2">
+      <code>RouteMatch|V2RouteMatch</code>
+      <code>RouteMatch|V2RouteMatch</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Factory/AclAuthorizationFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>AclAuthorizationFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="5">
+      <code>$action</code>
+      <code>$methods</code>
+      <code>$privileges</code>
+      <code>$privileges['collection']</code>
+      <code>$privileges['entity']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$controllerService</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-mvc-auth']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="5">
+      <code>$action</code>
+      <code>$config</code>
+      <code>$flag</code>
+      <code>$methods</code>
+      <code>$privileges</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$config['api-tools-mvc-auth']['authorization']</code>
+    </MixedReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/ApacheResolverFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>ApacheResolverFactory</code>
+    </DeprecatedInterface>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>false|ApacheResolver</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedArgument occurrences="1">
+      <code>ApacheResolver::class</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-mvc-auth']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$htpasswd</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>false|ApacheResolver</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>new ApacheResolver($htpasswd)</code>
+    </MixedReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <UndefinedClass occurrences="2">
+      <code>ApacheResolver</code>
+      <code>ApacheResolver</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="2">
+      <code>false|ApacheResolver</code>
+      <code>false|ApacheResolver</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Factory/AuthenticationAdapterDelegatorFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>AuthenticationAdapterDelegatorFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="3">
+      <code>$data</code>
+      <code>$listener</code>
+      <code>$type</code>
+      <code>$type</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="2">
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="3">
+      <code>$data</code>
+      <code>$listener</code>
+      <code>$type</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>DefaultAuthenticationListener</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="2">
+      <code>$listener</code>
+      <code>$listener</code>
+    </MixedReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/AuthenticationHttpAdapterFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get('authentication')</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Factory/AuthenticationOAuth2AdapterFactory.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$type</code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Factory/AuthenticationServiceFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>AuthenticationServiceFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="1">
+      <code>$container-&gt;get(NonPersistent::class)</code>
+    </MixedArgument>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/DefaultAuthHttpAdapterFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DefaultAuthHttpAdapterFactory</code>
+    </DeprecatedInterface>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>HttpAuth|false</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedArgument occurrences="1">
+      <code>$config['api-tools-mvc-auth']['authentication']['http']</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-mvc-auth']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/DefaultAuthenticationListenerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DefaultAuthenticationListenerFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="4">
+      <code>$authService</code>
+      <code>$config['api-tools-oauth2']['storage']</code>
+      <code>$factory()</code>
+      <code>$httpAdapter</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="6">
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+      <code>$config['api-tools-mvc-auth']['authentication']</code>
+      <code>$config['api-tools-oauth2']['storage']</code>
+      <code>$config['api-tools-oauth2']['storage']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="3">
+      <code>$authService</code>
+      <code>$factory</code>
+      <code>$httpAdapter</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$factory()</code>
+    </MixedFunctionCall>
+    <MixedInferredReturnType occurrences="2">
+      <code>array</code>
+      <code>array|false</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>getBasicResolver</code>
+      <code>getDigestResolver</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="2">
+      <code>$config['api-tools-mvc-auth']['authentication']['map']</code>
+      <code>$config['api-tools-mvc-auth']['authentication']['types']</code>
+    </MixedReturnStatement>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+    <TooManyArguments occurrences="1">
+      <code>$serverFactory</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Factory/DefaultAuthorizationListenerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DefaultAuthorizationListenerFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="1">
+      <code>$authorization</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$authorization</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/DefaultResourceResolverListenerFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>DefaultResourceResolverListenerFactory</code>
+    </DeprecatedInterface>
+    <MixedArgument occurrences="1">
+      <code>$config</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$restConfig['route_identifier_name']</code>
+    </MixedArrayAccess>
+    <MixedArrayOffset occurrences="1">
+      <code>$restServices[$controllerService]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="4">
+      <code>$config</code>
+      <code>$controllerService</code>
+      <code>$restConfig</code>
+      <code>$restServices[$controllerService]</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/FileResolverFactory.php">
+    <DeprecatedInterface occurrences="1">
+      <code>FileResolverFactory</code>
+    </DeprecatedInterface>
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>false|FileResolver</code>
+    </ImplementedReturnTypeMismatch>
+    <MixedArgument occurrences="1">
+      <code>$htdigest</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-mvc-auth']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$config</code>
+      <code>$htdigest</code>
+    </MixedAssignment>
+    <ParamNameMismatch occurrences="1">
+      <code>$container</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Factory/HttpAdapterFactory.php">
+    <MixedArgument occurrences="9">
+      <code>$config['basic_resolver_factory']</code>
+      <code>$config['basic_resolver_factory']</code>
+      <code>$config['digest_resolver_factory']</code>
+      <code>$config['digest_resolver_factory']</code>
+      <code>$config['htdigest']</code>
+      <code>$config['htpasswd']</code>
+      <code>$container-&gt;get($config['basic_resolver_factory'])</code>
+      <code>$container-&gt;get($config['digest_resolver_factory'])</code>
+      <code>$key</code>
+    </MixedArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>get</code>
+      <code>get</code>
+    </PossiblyNullReference>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>is_string($key)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/Factory/NamedOAuth2ServerFactory.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$type</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="3">
+      <code>$adapterConfig['storage']</code>
+      <code>$oauth2Config</code>
+      <code>$oauth2Config</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="5">
+      <code>$adapterConfig['storage']</code>
+      <code>$adapterConfig['storage']</code>
+      <code>$config['api-tools-mvc-auth']</code>
+      <code>$config['api-tools-oauth2']</code>
+      <code>$servers-&gt;api[$type]</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$servers-&gt;api[$type]</code>
+    </MixedArrayAssignment>
+    <MixedArrayOffset occurrences="3">
+      <code>$servers-&gt;api[$type]</code>
+      <code>$servers-&gt;api[$type]</code>
+      <code>$servers-&gt;api[$type]</code>
+    </MixedArrayOffset>
+    <MixedAssignment occurrences="5">
+      <code>$adapterConfig</code>
+      <code>$config</code>
+      <code>$mvcAuthConfig</code>
+      <code>$name</code>
+      <code>$oauth2Config</code>
+    </MixedAssignment>
+    <UnusedVariable occurrences="1">
+      <code>$name</code>
+    </UnusedVariable>
+  </file>
+  <file src="src/Factory/OAuth2ServerFactory.php">
+    <ArgumentTypeCoercion occurrences="4">
+      <code>$server-&gt;getStorage('client_credentials')</code>
+      <code>$server-&gt;getStorage('jwt_bearer')</code>
+      <code>$server-&gt;getStorage('refresh_token')</code>
+      <code>$server-&gt;getStorage('user_credentials')</code>
+    </ArgumentTypeCoercion>
+    <InvalidArgument occurrences="1">
+      <code>self::createPdoConfig($config)</code>
+    </InvalidArgument>
+    <InvalidCast occurrences="1">
+      <code>self::createPdoConfig($config)</code>
+    </InvalidCast>
+    <MixedArgument occurrences="5">
+      <code>$dbLocatorName</code>
+      <code>$oauth2Config</code>
+      <code>$oauth2Config['grant_types']</code>
+      <code>$options</code>
+      <code>$options['audience']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$config['storage']</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$allConfig['api-tools-oauth2']</code>
+    </MixedArrayAccess>
+    <MixedArrayAssignment occurrences="1">
+      <code>$options['connect']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="19">
+      <code>$accessLifetime</code>
+      <code>$allConfig</code>
+      <code>$allowImplicit</code>
+      <code>$audience</code>
+      <code>$clientOptions['allow_credentials_in_request_body']</code>
+      <code>$dbLocatorName</code>
+      <code>$enforceState</code>
+      <code>$mongo</code>
+      <code>$oauth2Config</code>
+      <code>$options</code>
+      <code>$options</code>
+      <code>$options</code>
+      <code>$password</code>
+      <code>$refreshOptions['always_issue_new_refresh_token']</code>
+      <code>$refreshOptions['refresh_token_lifetime']</code>
+      <code>$refreshOptions['unset_refresh_token_after_use']</code>
+      <code>$server</code>
+      <code>$storage[$key]</code>
+      <code>$username</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="2">
+      <code>MongoDB</code>
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedPropertyFetch occurrences="1">
+      <code>$mongo-&gt;{$config['database']}</code>
+    </MixedPropertyFetch>
+    <MixedReturnStatement occurrences="2">
+      <code>$container-&gt;get($dbLocatorName)</code>
+      <code>$mongo-&gt;{$config['database']}</code>
+    </MixedReturnStatement>
+    <PossiblyNullArgument occurrences="4">
+      <code>$server-&gt;getStorage('client_credentials')</code>
+      <code>$server-&gt;getStorage('jwt_bearer')</code>
+      <code>$server-&gt;getStorage('refresh_token')</code>
+      <code>$server-&gt;getStorage('user_credentials')</code>
+    </PossiblyNullArgument>
+    <UndefinedClass occurrences="1">
+      <code>MongoClient</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="2">
+      <code>MongoDB</code>
+      <code>array|ArrayAccess</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="src/Identity/AuthenticatedIdentity.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>null|string</code>
+    </ImplementedReturnTypeMismatch>
+    <PropertyNotSetInConstructor occurrences="1">
+      <code>AuthenticatedIdentity</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Identity/IdentityInterface.php">
+    <MissingReturnType occurrences="1">
+      <code>getAuthenticationIdentity</code>
+    </MissingReturnType>
+  </file>
+  <file src="src/Module.php">
+    <MixedArgument occurrences="6">
+      <code>$authentication</code>
+      <code>$this-&gt;container-&gt;get(DefaultAuthenticationListener::class)</code>
+      <code>$this-&gt;container-&gt;get(DefaultAuthenticationPostListener::class)</code>
+      <code>$this-&gt;container-&gt;get(DefaultAuthorizationListener::class)</code>
+      <code>$this-&gt;container-&gt;get(DefaultAuthorizationPostListener::class)</code>
+      <code>$this-&gt;container-&gt;get(DefaultResourceResolverListener::class)</code>
+    </MixedArgument>
+    <MixedArrayAssignment occurrences="1">
+      <code>$config['service_manager']['factories']</code>
+    </MixedArrayAssignment>
+    <MixedAssignment occurrences="1">
+      <code>$authentication</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>include __DIR__ . '/../config/module.config.php'</code>
+    </MixedReturnStatement>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$config</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference occurrences="2">
+      <code>getMergedConfig</code>
+      <code>has</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setService</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="src/MvcAuthEvent.php">
+    <MixedMethodCall occurrences="3">
+      <code>getIdentity</code>
+      <code>getStorage</code>
+      <code>write</code>
+    </MixedMethodCall>
+    <PropertyNotSetInConstructor occurrences="3">
+      <code>$authenticationResult</code>
+      <code>MvcAuthEvent</code>
+      <code>MvcAuthEvent</code>
+    </PropertyNotSetInConstructor>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $flag</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;authenticationResult !== null</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/MvcRouteListener.php">
+    <MissingClosureParamType occurrences="4">
+      <code>$r</code>
+      <code>$r</code>
+      <code>$r</code>
+      <code>$r</code>
+    </MissingClosureParamType>
+    <MixedArgument occurrences="7">
+      <code>$identity</code>
+      <code>$mvcAuthEvent-&gt;getAuthenticationResult()-&gt;getIdentity()</code>
+      <code>$mvcAuthEvent::EVENT_AUTHENTICATION</code>
+      <code>$mvcAuthEvent::EVENT_AUTHENTICATION_POST</code>
+      <code>$mvcAuthEvent::EVENT_AUTHORIZATION</code>
+      <code>$mvcAuthEvent::EVENT_AUTHORIZATION_POST</code>
+      <code>$result-&gt;getIdentity()</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$result</code>
+      <code>$result</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>null|Response</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$responses-&gt;last()</code>
+    </MixedReturnStatement>
+    <PossiblyNullReference occurrences="2">
+      <code>getIdentity</code>
+      <code>isValid</code>
+    </PossiblyNullReference>
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>isOptions</code>
+      <code>isOptions</code>
+      <code>isOptions</code>
+      <code>isOptions</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/Authentication/DefaultAuthenticationListenerTest.php">
+    <DeprecatedMethod occurrences="13">
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setHttpAdapter</code>
+      <code>setOauth2Server</code>
+      <code>setOauth2Server</code>
+      <code>setOauth2Server</code>
+    </DeprecatedMethod>
+    <MixedMethodCall occurrences="2">
+      <code>set</code>
+      <code>set</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="10">
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidArrayAccess occurrences="2">
+      <code>$authHeaders[0]</code>
+      <code>$authHeaders[0]</code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyInvalidMethodCall occurrences="12">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyNullArgument occurrences="3">
+      <code>$identity</code>
+      <code>$identity</code>
+      <code>$identity</code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedMethod occurrences="14">
+      <code>$authHeaders</code>
+      <code>$authHeaders</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/Authentication/DefaultAuthenticationPostListenerTest.php">
+    <MixedAssignment occurrences="5">
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$listener</code>
+      <code>$response</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="4">
+      <code>$listener($this-&gt;mvcAuthEvent)</code>
+      <code>$listener($this-&gt;mvcAuthEvent)</code>
+      <code>$listener($this-&gt;mvcAuthEvent)</code>
+      <code>$listener($this-&gt;mvcAuthEvent)</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="9">
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getReasonPhrase</code>
+      <code>getResponse</code>
+      <code>getStatusCode</code>
+      <code>setAuthenticationResult</code>
+      <code>setAuthenticationResult</code>
+      <code>setAuthenticationResult</code>
+      <code>setResponse</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="4">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authorization</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="8">
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Authentication/HttpAdapterTest.php">
+    <MixedArgument occurrences="12">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="4">
+      <code>addHeaderLine</code>
+      <code>addHeaderLine</code>
+      <code>getHeaders</code>
+      <code>getHeaders</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="4">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="12">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Authentication/OAuth2AdapterTest.php">
+    <MissingClosureParamType occurrences="4">
+      <code>$subject</code>
+      <code>$subject</code>
+      <code>$subject</code>
+      <code>$subject</code>
+    </MissingClosureParamType>
+    <MixedAssignment occurrences="1">
+      <code>$instance</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="33">
+      <code>authenticate</code>
+      <code>authenticate</code>
+      <code>authenticate</code>
+      <code>authenticate</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>getFieldValue</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>with</code>
+      <code>with</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>getFieldValue</code>
+    </PossiblyInvalidMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;adapter</code>
+      <code>$this-&gt;oauthServer</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="8">
+      <code>$this-&gt;adapter</code>
+      <code>$this-&gt;adapter</code>
+      <code>$this-&gt;adapter</code>
+      <code>$this-&gt;adapter</code>
+      <code>$this-&gt;oauthServer</code>
+      <code>$this-&gt;oauthServer</code>
+      <code>$this-&gt;oauthServer</code>
+      <code>$this-&gt;oauthServer</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Authorization/DefaultAuthorizationListenerTest.php">
+    <InvalidArgument occurrences="2">
+      <code>$container</code>
+      <code>[]</code>
+    </InvalidArgument>
+    <InvalidPropertyAssignmentValue occurrences="1">
+      <code>new AclAuthorization()</code>
+    </InvalidPropertyAssignmentValue>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$routeMatch</code>
+    </PossiblyInvalidArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>setParam</code>
+    </PossiblyNullReference>
+    <UndefinedDocblockClass occurrences="3">
+      <code>$this-&gt;authorization</code>
+      <code>$this-&gt;authorization</code>
+      <code>Acl</code>
+    </UndefinedDocblockClass>
+    <UndefinedInterfaceMethod occurrences="1">
+      <code>setMethod</code>
+    </UndefinedInterfaceMethod>
+  </file>
+  <file src="test/Authorization/DefaultAuthorizationPostListenerTest.php">
+    <UndefinedInterfaceMethod occurrences="4">
+      <code>getReasonPhrase</code>
+      <code>getStatusCode</code>
+      <code>getStatusCode</code>
+      <code>setStatusCode</code>
+    </UndefinedInterfaceMethod>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authorization</code>
+    </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="test/Authorization/DefaultResourceResolverListenerTest.php">
+    <MixedAssignment occurrences="18">
+      <code>$mvcEvent</code>
+      <code>$mvcEvent</code>
+      <code>$mvcEvent</code>
+      <code>$mvcEvent</code>
+      <code>$mvcEvent</code>
+      <code>$mvcEvent</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$request</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+      <code>$routeMatch</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="35">
+      <code>buildResourceString</code>
+      <code>buildResourceString</code>
+      <code>buildResourceString</code>
+      <code>buildResourceString</code>
+      <code>buildResourceString</code>
+      <code>buildResourceString</code>
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getMvcEvent</code>
+      <code>getQuery</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRequest</code>
+      <code>getRouteMatch</code>
+      <code>getRouteMatch</code>
+      <code>getRouteMatch</code>
+      <code>getRouteMatch</code>
+      <code>getRouteMatch</code>
+      <code>getRouteMatch</code>
+      <code>set</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+      <code>setParam</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$routeMatch</code>
+    </PossiblyInvalidArgument>
+    <UndefinedThisPropertyAssignment occurrences="5">
+      <code>$this-&gt;authentication</code>
+      <code>$this-&gt;authorization</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;restControllers</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="12">
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+      <code>$this-&gt;mvcAuthEvent</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/AclAuthorizationFactoryTest.php">
+    <MixedArgument occurrences="7">
+      <code>$method</code>
+      <code>$method</code>
+      <code>$method</code>
+      <code>$resource</code>
+      <code>$rules</code>
+      <code>$rules</code>
+      <code>$rules</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$config['api-tools-mvc-auth']['authorization']</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="11">
+      <code>$action</code>
+      <code>$actionRules</code>
+      <code>$authorizations</code>
+      <code>$expected</code>
+      <code>$expected</code>
+      <code>$expected</code>
+      <code>$method</code>
+      <code>$method</code>
+      <code>$method</code>
+      <code>$resource</code>
+      <code>$rules</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$action</code>
+    </MixedOperand>
+  </file>
+  <file src="test/Factory/AuthenticationAdapterDelegatorFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;callback</code>
+      <code>$this-&gt;callback</code>
+    </MixedArgument>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;callback</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="4">
+      <code>$this-&gt;callback</code>
+      <code>$this-&gt;callback</code>
+      <code>$this-&gt;listener</code>
+      <code>$this-&gt;listener</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/AuthenticationHttpAdapterFactoryTest.php">
+    <InvalidDocblock occurrences="1">
+      <code>public function validConfiguration(): array</code>
+    </InvalidDocblock>
+    <MixedArgument occurrences="3">
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+    </MixedArgument>
+    <MixedInferredReturnType occurrences="1"/>
+    <MixedMethodCall occurrences="16">
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>expects</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>with</code>
+      <code>with</code>
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testRaisesExceptionIfMissingConfigurationOptions</code>
+    </PossiblyInvalidArgument>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="3">
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/AuthenticationOAuth2AdapterFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="4">
+      <code>expects</code>
+      <code>method</code>
+      <code>will</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="2">
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/DefaultAuthenticationListenerFactoryTest.php">
+    <MixedArgument occurrences="4">
+      <code>$adapters</code>
+      <code>ApacheResolver::class</code>
+      <code>AuthHttpAdapter::class</code>
+      <code>FileResolver::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="9">
+      <code>$adapter</code>
+      <code>$adapters</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+      <code>$httpAdapter</code>
+    </MixedAssignment>
+    <UndefinedClass occurrences="3">
+      <code>ApacheResolver</code>
+      <code>AuthHttpAdapter</code>
+      <code>FileResolver</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/Factory/NamedOAuth2ServerFactoryTest.php">
+    <MixedAssignment occurrences="8">
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$factory</code>
+      <code>$server</code>
+      <code>$server</code>
+      <code>$server</code>
+      <code>$server</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="9">
+      <code>$factory('test')</code>
+      <code>$factory('test')</code>
+      <code>$factory('test')</code>
+      <code>$factory('test2')</code>
+      <code>$factory('unknown')</code>
+      <code>$factory()</code>
+      <code>$factory()</code>
+      <code>$factory()</code>
+      <code>$factory()</code>
+    </MixedFunctionCall>
+    <MixedMethodCall occurrences="4">
+      <code>__invoke</code>
+      <code>__invoke</code>
+      <code>__invoke</code>
+      <code>__invoke</code>
+    </MixedMethodCall>
+    <TooManyArguments occurrences="1">
+      <code>disableOriginalConstructor</code>
+    </TooManyArguments>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="8">
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;factory</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+      <code>$this-&gt;services</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Factory/OAuth2ServerFactoryTest.php">
+    <MixedArgument occurrences="2">
+      <code>$class</code>
+      <code>$storageConfig</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$storageConfig[$key]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$storageConfig</code>
+    </MixedAssignment>
+    <PossiblyNullArgument occurrences="1">
+      <code>$storage</code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$class</code>
+    </PossiblyUndefinedVariable>
+    <TooManyArguments occurrences="1">
+      <code>disableOriginalConstructor</code>
+    </TooManyArguments>
+  </file>
+  <file src="test/Identity/AuthenticatedIdentityTest.php">
+    <InvalidArgument occurrences="1">
+      <code>$this-&gt;authIdentity</code>
+    </InvalidArgument>
+    <MixedMethodCall occurrences="4">
+      <code>getAuthenticationIdentity</code>
+      <code>getName</code>
+      <code>getRoleId</code>
+      <code>setName</code>
+    </MixedMethodCall>
+    <MixedPropertyFetch occurrences="1">
+      <code>$this-&gt;authIdentity-&gt;name</code>
+    </MixedPropertyFetch>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;authIdentity</code>
+      <code>$this-&gt;identity</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="7">
+      <code>$this-&gt;authIdentity</code>
+      <code>$this-&gt;authIdentity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Identity/GuestIdentityTest.php">
+    <MixedMethodCall occurrences="3">
+      <code>getAuthenticationIdentity</code>
+      <code>getName</code>
+      <code>getRoleId</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;identity</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="6">
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+      <code>$this-&gt;identity</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Identity/IdentityPluginTest.php">
+    <MixedMethodCall occurrences="5">
+      <code>__invoke</code>
+      <code>__invoke</code>
+      <code>__invoke</code>
+      <code>setParam</code>
+      <code>setParam</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="2">
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;plugin</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="5">
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;event</code>
+      <code>$this-&gt;plugin</code>
+      <code>$this-&gt;plugin</code>
+      <code>$this-&gt;plugin</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/ModuleTest.php">
+    <InvalidArgument occurrences="4">
+      <code>$events</code>
+      <code>$services</code>
+      <code>$servicesConfig</code>
+      <code>[]</code>
+    </InvalidArgument>
+    <InvalidDocblock occurrences="1">
+      <code>public function expectedListeners(): array</code>
+    </InvalidDocblock>
+    <MismatchingDocblockParamType occurrences="1">
+      <code>callable(MvcEvent|MvcAuthEvent):null|Response</code>
+    </MismatchingDocblockParamType>
+    <MixedArgument occurrences="2">
+      <code>$config['service_manager']</code>
+      <code>$config['service_manager']</code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$config</code>
+    </MixedArgumentTypeCoercion>
+    <MixedInferredReturnType occurrences="1"/>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$listener</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="test/MvcAuthEventTest.php">
+    <InvalidScalarArgument occurrences="3">
+      <code>'success'</code>
+      <code>'success'</code>
+      <code>'success'</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="test/RouteMatchFactoryTrait.php">
+    <UndefinedDocblockClass occurrences="1">
+      <code>RouteMatch|V2RouteMatch</code>
+    </UndefinedDocblockClass>
+  </file>
+  <file src="test/TestAsset/AuthenticationService.php">
+    <MissingConstructor occurrences="1">
+      <code>$identity</code>
+    </MissingConstructor>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<psalm
+        totallyTyped="true"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="config"/>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name=".github"/>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/Authentication/AbstractAdapter.php
+++ b/src/Authentication/AbstractAdapter.php
@@ -27,7 +27,7 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function getTypeFromRequest(Request $request)
     {
-        $headers       = $request->getHeaders();
+        $request->getHeaders();
         $authorization = $request->getHeader('Authorization');
         if (! $authorization) {
             return false;

--- a/src/Authentication/DefaultAuthenticationListener.php
+++ b/src/Authentication/DefaultAuthenticationListener.php
@@ -63,6 +63,8 @@ class DefaultAuthenticationListener
      *
      * Adds the authentication adapter, and updates the list of supported
      * authentication types based on what the adapter provides.
+     *
+     * @return void
      */
     public function attach(AdapterInterface $adapter)
     {
@@ -78,6 +80,7 @@ class DefaultAuthenticationListener
      * merged with any types already discovered.
      *
      * @param array $types
+     * @return void
      */
     public function addAuthenticationTypes(array $types)
     {
@@ -144,6 +147,7 @@ class DefaultAuthenticationListener
      * Set the API/version to authentication type map.
      *
      * @param array $map
+     * @return void
      */
     public function setAuthMap(array $map)
     {
@@ -270,7 +274,7 @@ class DefaultAuthenticationListener
      * This method is triggered if no authentication type was discovered in the
      * request.
      */
-    private function triggerAdapterPreAuth(HttpRequest $request, HttpResponse $response)
+    private function triggerAdapterPreAuth(HttpRequest $request, HttpResponse $response): void
     {
         foreach ($this->adapters as $adapter) {
             $adapter->preAuth($request, $response);
@@ -304,7 +308,7 @@ class DefaultAuthenticationListener
      *
      * @deprecated
      */
-    private function attachHttpAdapter(MvcAuthEvent $mvcAuthEvent)
+    private function attachHttpAdapter(MvcAuthEvent $mvcAuthEvent): void
     {
         if (! $this->httpAdapter instanceof HttpAuth) {
             return;

--- a/src/Authentication/HttpAdapter.php
+++ b/src/Authentication/HttpAdapter.php
@@ -93,6 +93,8 @@ class HttpAdapter extends AbstractAdapter
      * Perform pre-flight authentication operations.
      *
      * If invoked, issues a client challenge.
+     *
+     * @return void
      */
     public function preAuth(Request $request, Response $response)
     {

--- a/src/Authentication/OAuth2Adapter.php
+++ b/src/Authentication/OAuth2Adapter.php
@@ -112,6 +112,8 @@ class OAuth2Adapter extends AbstractAdapter
      * Perform pre-flight authentication operations.
      *
      * Performs a no-op; nothing needs to happen for this adapter.
+     *
+     * @return void
      */
     public function preAuth(Request $request, Response $response)
     {
@@ -120,8 +122,7 @@ class OAuth2Adapter extends AbstractAdapter
     /**
      * Attempt to authenticate the current request.
      *
-     * @return false|Identity\IdentityInterface False on failure, IdentityInterface
-     *     otherwise
+     * @return Identity\AuthenticatedIdentity|Identity\GuestIdentity|Response
      */
     public function authenticate(Request $request, Response $response, MvcAuthEvent $mvcAuthEvent)
     {

--- a/src/Factory/AclAuthorizationFactory.php
+++ b/src/Factory/AclAuthorizationFactory.php
@@ -47,7 +47,6 @@ class AclAuthorizationFactory implements FactoryInterface
      *
      * Provided for backwards compatibility; proxies to __invoke().
      *
-     * @param ContainerInterface|ServiceLocatorInterface $container
      * @return AclAuthorization
      */
     public function createService(ServiceLocatorInterface $container)
@@ -91,8 +90,12 @@ class AclAuthorizationFactory implements FactoryInterface
      * @param array $aclConfig
      * @param bool $denyByDefault
      */
-    protected function createAclConfigFromPrivileges($controllerService, array $privileges, &$aclConfig, $denyByDefault)
-    {
+    protected function createAclConfigFromPrivileges(
+        $controllerService,
+        array $privileges,
+        &$aclConfig,
+        $denyByDefault
+    ): void {
         // Normalize the controller service name.
         // laminas-mvc will always pass the name using namespace seprators, but
         // the admin may write the name using dash seprators.

--- a/src/Factory/AuthenticationAdapterDelegatorFactory.php
+++ b/src/Factory/AuthenticationAdapterDelegatorFactory.php
@@ -59,16 +59,13 @@ class AuthenticationAdapterDelegatorFactory implements DelegatorFactoryInterface
 
     /**
      * Attach an adaper to the listener as described by $type and $data.
-     *
-     * @param string $type
-     * @param array $adapterConfig
      */
     private function attachAdapterOfType(
-        $type,
+        string $type,
         array $adapterConfig,
         ContainerInterface $container,
         DefaultAuthenticationListener $listener
-    ) {
+    ): void {
         if (
             ! isset($adapterConfig['adapter'])
             || ! is_string($adapterConfig['adapter'])

--- a/src/Factory/DefaultAuthHttpAdapterFactory.php
+++ b/src/Factory/DefaultAuthHttpAdapterFactory.php
@@ -15,9 +15,9 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
     /**
      * Create an object
      *
-     * @param string             $requestedName
-     * @param null|array         $options
-     * @return HttpAuth
+     * @param string     $requestedName
+     * @param null|array $options
+     * @return HttpAuth|false
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
@@ -41,7 +41,7 @@ class DefaultAuthHttpAdapterFactory implements FactoryInterface
      *
      * Provided for backwards compatibility; proxies to __invoke().
      *
-     * @return HttpAuth
+     * @return HttpAuth|false
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -34,6 +34,8 @@ class Module
 
     /**
      * Register a listener for the mergeConfig event.
+     *
+     * @return void
      */
     public function init(ModuleManager $moduleManager)
     {
@@ -46,6 +48,8 @@ class Module
      *
      * If the Laminas\ApiTools\OAuth2\Service\OAuth2Server is defined, and set to the
      * default, override it with the NamedOAuth2ServerFactory.
+     *
+     * @return void
      */
     public function onMergeConfig(ModuleEvent $e)
     {
@@ -65,6 +69,9 @@ class Module
         $configListener->setMergedConfig($config);
     }
 
+    /**
+     * @return void
+     */
     public function onBootstrap(MvcEvent $mvcEvent)
     {
         if (! $mvcEvent->getRequest() instanceof HttpRequest) {
@@ -112,6 +119,9 @@ class Module
         );
     }
 
+    /**
+     * @return void
+     */
     public function onAuthenticationPost(MvcAuthEvent $e)
     {
         if ($this->container->has('api-identity')) {
@@ -131,7 +141,7 @@ class Module
         return $this->mvcRouteListener;
     }
 
-    public function getContainer(): ?ContainerInterface
+    public function getContainer(): ?ServiceLocatorInterface
     {
         return $this->container;
     }

--- a/test/Authentication/DefaultAuthenticationListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationListenerTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php // phpcs:disable Generic.Files.LineLength.TooLong
 
 namespace LaminasTest\ApiTools\MvcAuth\Authentication;
 
@@ -76,13 +76,13 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->listener     = new DefaultAuthenticationListener();
     }
 
-    public function testInvokeReturnsEarlyWhenNotHttpRequest()
+    public function testInvokeReturnsEarlyWhenNotHttpRequest(): void
     {
         $this->mvcAuthEvent->getMvcEvent()->setRequest(new Request());
         $this->assertNull($this->listener->__invoke($this->mvcAuthEvent));
     }
 
-    public function testInvokeForBasicAuthAddsAuthorizationHeader()
+    public function testInvokeForBasicAuthAddsAuthorizationHeader(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',
@@ -139,7 +139,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         return ['identity' => $identity, 'mvc_event' => $this->mvcAuthEvent->getMvcEvent()];
     }
 
-    public function testInvokeForBasicAuthHasNoIdentityWhenNotValid()
+    public function testInvokeForBasicAuthHasNoIdentityWhenNotValid(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',
@@ -155,7 +155,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertNull($this->mvcAuthEvent->getIdentity());
     }
 
-    public function testInvokeForDigestAuthAddsAuthorizationHeader()
+    public function testInvokeForDigestAuthAddsAuthorizationHeader(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'digest',
@@ -212,7 +212,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /**
      * @group 23
      */
-    public function testListenerPullsDigestUsernameFromAuthenticationIdentityWhenCreatingAuthenticatedIdentityInstance()
+    public function testListenerPullsDigestUsernameFromAuthenticationIdentityWhenCreatingAuthenticatedIdentityInstance(): void
     {
         $httpAuth       = $this->getMockBuilder(HttpAuth::class)
             ->disableOriginalConstructor()
@@ -249,7 +249,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertEquals('user', $identity->getRoleId());
     }
 
-    public function testBearerTypeProxiesOAuthServer()
+    public function testBearerTypeProxiesOAuthServer(): void
     {
         $token = [
             'user_id' => 'test',
@@ -263,7 +263,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertIdentityMatchesToken($token, $identity);
     }
 
-    public function testQueryAccessTokenProxiesOAuthServer()
+    public function testQueryAccessTokenProxiesOAuthServer(): void
     {
         $token = [
             'user_id' => 'test',
@@ -546,7 +546,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /**
      * @group 55
      */
-    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasNoAuthMapEntryAndAuthSchemesAreDefined()
+    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasNoAuthMapEntryAndAuthSchemesAreDefined(): void
     {
         // Minimal HTTP adapter mock, as we are not expecting any method calls
         $httpAuth = $this->getMockBuilder(HttpAuth::class)
@@ -584,7 +584,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /**
      * @group 55
      */
-    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasAuthMapEntryNotInDefinedAuthSchemes()
+    public function testDoesNotPerformAuthenticationWhenMatchedControllerHasAuthMapEntryNotInDefinedAuthSchemes(): void
     {
         // Minimal HTTP adapter mock, as we are not expecting any method calls
         $httpAuth = $this->getMockBuilder(HttpAuth::class)
@@ -615,7 +615,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $identity);
     }
 
-    public function testAllowsAttachingAdapters()
+    public function testAllowsAttachingAdapters(): void
     {
         $types   = ['foo'];
         $adapter = $this->getMockBuilder(AdapterInterface::class)
@@ -627,7 +627,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->listener->attach($adapter);
     }
 
-    public function testCanRetrieveSupportedAuthenticationTypes()
+    public function testCanRetrieveSupportedAuthenticationTypes(): void
     {
         $types   = ['foo'];
         $adapter = $this->getMockBuilder(AdapterInterface::class)
@@ -640,7 +640,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertEquals($types, $this->listener->getAuthenticationTypes());
     }
 
-    public function testAdapterPreAuthIsTriggeredWhenNoTypeMatchedInRequest()
+    public function testAdapterPreAuthIsTriggeredWhenNoTypeMatchedInRequest(): void
     {
         $map = [
             'Foo\V2' => 'oauth2',
@@ -677,7 +677,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $identity);
     }
 
-    public function testMatchedAdapterIsAuthenticatedAgainst()
+    public function testMatchedAdapterIsAuthenticatedAgainst(): void
     {
         $map = [
             'Foo\V2' => 'oauth2',
@@ -720,7 +720,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertSame($expected, $identity);
     }
 
-    public function testFirstAdapterProvidingTypeIsAuthenticatedAgainst()
+    public function testFirstAdapterProvidingTypeIsAuthenticatedAgainst(): void
     {
         $map = [
             'Foo\V2' => 'oauth2',
@@ -776,14 +776,14 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertSame($expected, $identity);
     }
 
-    public function testListsProvidedNonAdapterAuthenticationTypes()
+    public function testListsProvidedNonAdapterAuthenticationTypes(): void
     {
         $types = ['foo'];
         $this->listener->addAuthenticationTypes($types);
         $this->assertEquals($types, $this->listener->getAuthenticationTypes());
     }
 
-    public function testListsCombinedAuthenticationTypes()
+    public function testListsCombinedAuthenticationTypes(): void
     {
         $types       = ['foo'];
         $customTypes = ['bar'];
@@ -801,7 +801,7 @@ class DefaultAuthenticationListenerTest extends TestCase
         $this->assertEquals(array_merge($customTypes, $types), $this->listener->getAuthenticationTypes());
     }
 
-    public function testOauth2RequestIncludesHeaders()
+    public function testOauth2RequestIncludesHeaders(): void
     {
         $this->request->getHeaders()->addHeaderLine('Authorization', 'Bearer TOKEN');
 
@@ -823,7 +823,7 @@ class DefaultAuthenticationListenerTest extends TestCase
     /**
      * @group 83
      */
-    public function testAllowsAdaptersToReturnResponsesAndReturnsThemDirectly()
+    public function testAllowsAdaptersToReturnResponsesAndReturnsThemDirectly(): void
     {
         $map = [
             'Foo\V2' => 'custom',

--- a/test/Authentication/DefaultAuthenticationPostListenerTest.php
+++ b/test/Authentication/DefaultAuthenticationPostListenerTest.php
@@ -31,20 +31,20 @@ class DefaultAuthenticationPostListenerTest extends TestCase
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 
-    public function testReturnsNullWhenEventDoesNotHaveAuthenticationResult()
+    public function testReturnsNullWhenEventDoesNotHaveAuthenticationResult(): void
     {
         $listener = $this->listener;
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testReturnsNullWhenAuthenticationResultIsValid()
+    public function testReturnsNullWhenAuthenticationResultIsValid(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->setAuthenticationResult(new AuthenticationResult(1, 'foo'));
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testReturnsComposedEventResponseWhenNotAuthorizedButNotAnHttpResponse()
+    public function testReturnsComposedEventResponseWhenNotAuthorizedButNotAnHttpResponse(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->setAuthenticationResult(new AuthenticationResult(0, 'foo'));
@@ -53,7 +53,7 @@ class DefaultAuthenticationPostListenerTest extends TestCase
         $this->assertSame($response, $listener($this->mvcAuthEvent));
     }
 
-    public function testReturns401ResponseWhenNotAuthorizedAndHttpResponseComposed()
+    public function testReturns401ResponseWhenNotAuthorizedAndHttpResponseComposed(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->setAuthenticationResult(new AuthenticationResult(0, 'foo'));

--- a/test/Authentication/HttpAdapterTest.php
+++ b/test/Authentication/HttpAdapterTest.php
@@ -36,7 +36,7 @@ class HttpAdapterTest extends TestCase
         );
     }
 
-    public function testAuthenticateReturnsGuestIdentityIfNoAuthorizationHeaderProvided()
+    public function testAuthenticateReturnsGuestIdentityIfNoAuthorizationHeaderProvided(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',
@@ -51,7 +51,7 @@ class HttpAdapterTest extends TestCase
         $this->assertInstanceOf(GuestIdentity::class, $result);
     }
 
-    public function testAuthenticateReturnsFalseIfInvalidCredentialsProvidedInAuthorizationHeader()
+    public function testAuthenticateReturnsFalseIfInvalidCredentialsProvidedInAuthorizationHeader(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',
@@ -68,7 +68,7 @@ class HttpAdapterTest extends TestCase
         $this->assertFalse($adapter->authenticate($this->request, $this->response, $this->event));
     }
 
-    public function testAuthenticateReturnsAuthenticatedIdentityIfValidCredentialsProvidedInAuthorizationHeader()
+    public function testAuthenticateReturnsAuthenticatedIdentityIfValidCredentialsProvidedInAuthorizationHeader(): void
     {
         $httpAuth = new HttpAuth([
             'accept_schemes' => 'basic',

--- a/test/Authentication/OAuth2AdapterTest.php
+++ b/test/Authentication/OAuth2AdapterTest.php
@@ -24,7 +24,7 @@ class OAuth2AdapterTest extends TestCase
     /**
      * @group 83
      */
-    public function testReturns401ResponseWhenErrorOccursDuringValidation()
+    public function testReturns401ResponseWhenErrorOccursDuringValidation(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
             ->disableOriginalConstructor()
@@ -68,7 +68,7 @@ class OAuth2AdapterTest extends TestCase
     /**
      * @group 83
      */
-    public function testReturns403ResponseWhenInvalidScopeDetected()
+    public function testReturns403ResponseWhenInvalidScopeDetected(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
             ->disableOriginalConstructor()
@@ -112,7 +112,7 @@ class OAuth2AdapterTest extends TestCase
     /**
      * @group 83
      */
-    public function testReturnsGuestIdentityIfOAuth2ResponseIsNotAnError()
+    public function testReturnsGuestIdentityIfOAuth2ResponseIsNotAnError(): void
     {
         $oauth2Response = $this->getMockBuilder(OAuth2Response::class)
             ->disableOriginalConstructor()
@@ -150,7 +150,7 @@ class OAuth2AdapterTest extends TestCase
     /**
      * @group 83
      */
-    public function testErrorResponseIncludesOAuth2ResponseHeaders()
+    public function testErrorResponseIncludesOAuth2ResponseHeaders(): void
     {
         $expectedHeaders = [
             'WWW-Authenticate' => 'Bearer realm="example.com", '

--- a/test/Authorization/AclAuthorizationFactoryTest.php
+++ b/test/Authorization/AclAuthorizationFactoryTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class AclAuthorizationFactoryTest extends TestCase
 {
-    public function testFactoryGeneratesAclFromConfiguration()
+    public function testFactoryGeneratesAclFromConfiguration(): void
     {
         $config = [
             [
@@ -57,7 +57,7 @@ class AclAuthorizationFactoryTest extends TestCase
         $this->assertFalse($acl->isAllowed('guest', 'LaminasCon\V1\Rpc\Message\Controller::message', 'POST'));
     }
 
-    public function testFactoryGeneratesBlacklistAclFromConfiguration()
+    public function testFactoryGeneratesBlacklistAclFromConfiguration(): void
     {
         $config = [
             'deny_by_default' => true,

--- a/test/Authorization/DefaultAuthorizationListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationListenerTest.php
@@ -94,21 +94,21 @@ class DefaultAuthorizationListenerTest extends TestCase
         return new Application($container);
     }
 
-    public function testBailsEarlyOnInvalidRequest()
+    public function testBailsEarlyOnInvalidRequest(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->getMvcEvent()->setRequest(new Request());
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testBailsEarlyOnInvalidResponse()
+    public function testBailsEarlyOnInvalidResponse(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->getMvcEvent()->setResponse(new Response());
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testBailsEarlyOnMissingRouteMatch()
+    public function testBailsEarlyOnMissingRouteMatch(): void
     {
         $listener = $this->listener;
 
@@ -122,13 +122,13 @@ class DefaultAuthorizationListenerTest extends TestCase
         $this->assertNull($listener($mvcAuthEvent));
     }
 
-    public function testBailsEarlyOnMissingIdentity()
+    public function testBailsEarlyOnMissingIdentity(): void
     {
         $listener = $this->listener;
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testBailsEarlyIfMvcAuthEventIsAuthorizedAlready()
+    public function testBailsEarlyIfMvcAuthEventIsAuthorizedAlready(): void
     {
         $listener = $this->listener;
         // Setting identity to ensure we don't get a false positive
@@ -137,7 +137,7 @@ class DefaultAuthorizationListenerTest extends TestCase
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testReturnsTrueIfIdentityPassesAcls()
+    public function testReturnsTrueIfIdentityPassesAcls(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->getMvcEvent()->getRouteMatch()->setParam('controller', 'Foo\Bar\Controller');
@@ -146,7 +146,7 @@ class DefaultAuthorizationListenerTest extends TestCase
         $this->assertTrue($listener($this->mvcAuthEvent));
     }
 
-    public function testReturnsFalseIfIdentityFailsAcls()
+    public function testReturnsFalseIfIdentityFailsAcls(): void
     {
         $listener = $this->listener;
         $this->authorization->addResource('Foo\Bar\Controller::index');

--- a/test/Authorization/DefaultAuthorizationPostListenerTest.php
+++ b/test/Authorization/DefaultAuthorizationPostListenerTest.php
@@ -36,14 +36,14 @@ class DefaultAuthorizationPostListenerTest extends TestCase
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 
-    public function testReturnsNullWhenEventIsAuthorized()
+    public function testReturnsNullWhenEventIsAuthorized(): void
     {
         $listener = $this->listener;
         $this->mvcAuthEvent->setIsAuthorized(true);
         $this->assertNull($listener($this->mvcAuthEvent));
     }
 
-    public function testResetsResponseStatusTo200WhenEventIsAuthorized()
+    public function testResetsResponseStatusTo200WhenEventIsAuthorized(): void
     {
         $listener = $this->listener;
         $response = $this->mvcAuthEvent->getMvcEvent()->getResponse();
@@ -53,7 +53,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testReturnsComposedEventResponseWhenNotAuthorizedButNotAnHttpResponse()
+    public function testReturnsComposedEventResponseWhenNotAuthorizedButNotAnHttpResponse(): void
     {
         $listener = $this->listener;
         $response = new Response();
@@ -61,7 +61,7 @@ class DefaultAuthorizationPostListenerTest extends TestCase
         $this->assertSame($response, $listener($this->mvcAuthEvent));
     }
 
-    public function testReturns403ResponseWhenNotAuthorizedAndHttpResponseComposed()
+    public function testReturns403ResponseWhenNotAuthorizedAndHttpResponseComposed(): void
     {
         $listener = $this->listener;
         $response = $this->mvcAuthEvent->getMvcEvent()->getResponse();

--- a/test/Authorization/DefaultResourceResolverListenerTest.php
+++ b/test/Authorization/DefaultResourceResolverListenerTest.php
@@ -41,7 +41,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         return new MvcAuthEvent($mvcEvent, $this->authentication, $this->authorization);
     }
 
-    public function testBuildResourceStringReturnsFalseIfControllerIsMissing()
+    public function testBuildResourceStringReturnsFalseIfControllerIsMissing(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();
@@ -49,7 +49,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         $this->assertFalse($this->listener->buildResourceString($routeMatch, $request));
     }
 
-    public function testBuildResourceStringReturnsEntityWhenIdentifierIsZero()
+    public function testBuildResourceStringReturnsEntityWhenIdentifierIsZero(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();
@@ -63,7 +63,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         );
     }
 
-    public function testBuildResourceStringReturnsControllerActionFormattedStringForNonRestController()
+    public function testBuildResourceStringReturnsControllerActionFormattedStringForNonRestController(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();
@@ -73,7 +73,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         $this->assertEquals('Foo\Bar\Controller::foo', $this->listener->buildResourceString($routeMatch, $request));
     }
 
-    public function testBuildResourceStringReturnsControllerNameAndCollectionIfNoIdentifierAvailable()
+    public function testBuildResourceStringReturnsControllerNameAndCollectionIfNoIdentifierAvailable(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();
@@ -85,7 +85,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         );
     }
 
-    public function testBuildResourceStringReturnsControllerNameAndResourceIfIdentifierInRouteMatch()
+    public function testBuildResourceStringReturnsControllerNameAndResourceIfIdentifierInRouteMatch(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();
@@ -98,7 +98,7 @@ class DefaultResourceResolverListenerTest extends TestCase
         );
     }
 
-    public function testBuildResourceStringReturnsControllerNameAndResourceIfIdentifierInQueryString()
+    public function testBuildResourceStringReturnsControllerNameAndResourceIfIdentifierInQueryString(): void
     {
         $mvcEvent   = $this->mvcAuthEvent->getMvcEvent();
         $routeMatch = $mvcEvent->getRouteMatch();

--- a/test/Factory/AclAuthorizationFactoryTest.php
+++ b/test/Factory/AclAuthorizationFactoryTest.php
@@ -73,7 +73,7 @@ class AclAuthorizationFactoryTest extends TestCase
     /**
      * @dataProvider whitelistAclProvider
      */
-    public function testCanCreateWhitelistAcl(array $config)
+    public function testCanCreateWhitelistAcl(array $config): void
     {
         $this->services->setService('config', $config);
 
@@ -114,7 +114,7 @@ class AclAuthorizationFactoryTest extends TestCase
         }
     }
 
-    public function testBlacklistAclSpecificationHonorsBooleansSetForMethods()
+    public function testBlacklistAclSpecificationHonorsBooleansSetForMethods(): void
     {
         $config = [
             'api-tools-mvc-auth' => [
@@ -187,7 +187,7 @@ class AclAuthorizationFactoryTest extends TestCase
         }
     }
 
-    public function testBlacklistAclsDenyByDefaultForUnspecifiedHttpMethods()
+    public function testBlacklistAclsDenyByDefaultForUnspecifiedHttpMethods(): void
     {
         $config = [
             'api-tools-mvc-auth' => [
@@ -248,7 +248,7 @@ class AclAuthorizationFactoryTest extends TestCase
         $this->assertTrue($acl->isAllowed('guest', 'Foo\Bar\RpcController::do', 'DELETE'));
     }
 
-    public function testRpcActionsAreNormalizedWhenCreatingAcl()
+    public function testRpcActionsAreNormalizedWhenCreatingAcl(): void
     {
         $config = [
             'api-tools-mvc-auth' => [

--- a/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
+++ b/test/Factory/AuthenticationAdapterDelegatorFactoryTest.php
@@ -24,12 +24,12 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
         $this->services = new ServiceManager();
         $this->factory  = new AuthenticationAdapterDelegatorFactory();
         $this->listener = $listener = new DefaultAuthenticationListener();
-        $this->callback = function () use ($listener) {
+        $this->callback = function () use ($listener): DefaultAuthenticationListener {
             return $listener;
         };
     }
 
-    public function testReturnsListenerWithNoAdaptersWhenNoAdaptersAreInConfiguration()
+    public function testReturnsListenerWithNoAdaptersWhenNoAdaptersAreInConfiguration(): void
     {
         $config = [];
         $this->services->setService('config', $config);
@@ -45,7 +45,7 @@ class AuthenticationAdapterDelegatorFactoryTest extends TestCase
         $this->assertEquals([], $listener->getAuthenticationTypes());
     }
 
-    public function testReturnsListenerWithConfiguredAdapters()
+    public function testReturnsListenerWithConfiguredAdapters(): void
     {
         $config = [
             // ensure top-level api-tools-oauth2 are available

--- a/test/Factory/AuthenticationHttpAdapterFactoryTest.php
+++ b/test/Factory/AuthenticationHttpAdapterFactoryTest.php
@@ -16,7 +16,7 @@ class AuthenticationHttpAdapterFactoryTest extends TestCase
         $this->services = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
     }
 
-    public function testRaisesExceptionIfNoAuthenticationServicePresent()
+    public function testRaisesExceptionIfNoAuthenticationServicePresent(): void
     {
         $this->services->expects($this->atLeastOnce())
             ->method('has')

--- a/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
+++ b/test/Factory/AuthenticationOAuth2AdapterFactoryTest.php
@@ -40,7 +40,7 @@ class AuthenticationOAuth2AdapterFactoryTest extends TestCase
         AuthenticationOAuth2AdapterFactory::factory('foo', $config, $this->services);
     }
 
-    public function testCreatesInstanceFromValidConfiguration()
+    public function testCreatesInstanceFromValidConfiguration(): void
     {
         $config = [
             'adapter' => 'pdo',

--- a/test/Factory/DefaultAuthenticationListenerFactoryTest.php
+++ b/test/Factory/DefaultAuthenticationListenerFactoryTest.php
@@ -37,7 +37,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->factory = new Factory\DefaultAuthenticationListenerFactory();
     }
 
-    public function testCreatingOAuth2ServerFromStorageService()
+    public function testCreatingOAuth2ServerFromStorageService(): void
     {
         $adapter = $this->getMockBuilder(PdoStorage::class)->disableOriginalConstructor()->getMock();
 
@@ -66,7 +66,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithNoConfigServiceReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithNoConfigServiceReturnsListenerWithNoHttpAdapter(): void
     {
         $factory = $this->factory;
 
@@ -78,7 +78,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithConfigMissingMvcAuthSectionReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithConfigMissingMvcAuthSectionReturnsListenerWithNoHttpAdapter(): void
     {
         $this->services->setService('config', []);
         $factory = $this->factory;
@@ -91,7 +91,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithConfigMissingAuthenticationSubSectionReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithConfigMissingAuthenticationSubSectionReturnsListenerWithNoHttpAdapter(): void
     {
         $this->services->setService('config', ['api-tools-mvc-auth' => []]);
         $factory = $this->factory;
@@ -104,7 +104,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithConfigMissingHttpSubSubSectionReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithConfigMissingHttpSubSubSectionReturnsListenerWithNoHttpAdapter(): void
     {
         $this->services->setService('config', ['api-tools-mvc-auth' => ['authentication' => []]]);
         $factory = $this->factory;
@@ -117,7 +117,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithConfigMissingAcceptSchemesRaisesException()
+    public function testCallingFactoryWithConfigMissingAcceptSchemesRaisesException(): void
     {
         $this->services->setService(
             'config',
@@ -137,7 +137,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $factory($this->services, 'DefaultAuthenticationListener');
     }
 
-    public function testCallingFactoryWithBasicSchemeButMissingHtpasswdValueReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithBasicSchemeButMissingHtpasswdValueReturnsListenerWithNoHttpAdapter(): void
     {
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [
@@ -159,7 +159,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithDigestSchemeButMissingHtdigestValueReturnsListenerWithNoHttpAdapter()
+    public function testCallingFactoryWithDigestSchemeButMissingHtdigestValueReturnsListenerWithNoHttpAdapter(): void
     {
         $this->services->setService('config', [
             'api-tools-mvc-auth' => [
@@ -183,7 +183,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertNotInstanceOf(HttpBasic::class, $httpAdapter);
     }
 
-    public function testCallingFactoryWithBasicSchemeAndHtpasswdValueReturnsListenerWithHttpAdapter()
+    public function testCallingFactoryWithBasicSchemeAndHtpasswdValueReturnsListenerWithHttpAdapter(): void
     {
         $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
@@ -207,7 +207,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertContains('basic', $listener->getAuthenticationTypes());
     }
 
-    public function testCallingFactoryWithDigestSchemeAndHtdigestValueReturnsListenerWithHttpAdapter()
+    public function testCallingFactoryWithDigestSchemeAndHtdigestValueReturnsListenerWithHttpAdapter(): void
     {
         $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
@@ -231,7 +231,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertContains('digest', $listener->getAuthenticationTypes());
     }
 
-    public function testCallingFactoryWithCustomAuthenticationTypesReturnsListenerComposingThem()
+    public function testCallingFactoryWithCustomAuthenticationTypesReturnsListenerComposingThem(): void
     {
         $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);
@@ -258,7 +258,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertEquals(['digest', 'token'], $listener->getAuthenticationTypes());
     }
 
-    public function testFactoryWillUsePreconfiguredOAuth2ServerInstanceProvidedByLaminasOAuth2()
+    public function testFactoryWillUsePreconfiguredOAuth2ServerInstanceProvidedByLaminasOAuth2(): void
     {
         // Configure mock OAuth2 Server
         $oauth2Server = $this->getMockBuilder(OAuth2Server::class)->disableOriginalConstructor()->getMock();
@@ -295,7 +295,7 @@ class DefaultAuthenticationListenerFactoryTest extends TestCase
         $this->assertSame($oauth2Server, $actualOauth2Server);
     }
 
-    public function testCallingFactoryWithAuthenticationMapReturnsListenerComposingMap()
+    public function testCallingFactoryWithAuthenticationMapReturnsListenerComposingMap(): void
     {
         $authenticationService = $this->getMockBuilder(AuthenticationServiceInterface::class)->getMock();
         $this->services->setService('authentication', $authenticationService);

--- a/test/Factory/HttpAdapterFactoryTest.php
+++ b/test/Factory/HttpAdapterFactoryTest.php
@@ -25,7 +25,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->htdigest = __DIR__ . '/../TestAsset/htdigest';
     }
 
-    public function testFactoryRaisesExceptionWhenNoAcceptSchemesPresent()
+    public function testFactoryRaisesExceptionWhenNoAcceptSchemesPresent(): void
     {
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('accept_schemes');
@@ -59,7 +59,7 @@ class HttpAdapterFactoryTest extends TestCase
         HttpAdapterFactory::factory(['accept_schemes' => $acceptSchemes]);
     }
 
-    public function testFactoryRaisesExceptionWhenRealmIsMissing()
+    public function testFactoryRaisesExceptionWhenRealmIsMissing(): void
     {
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('realm');
@@ -68,7 +68,7 @@ class HttpAdapterFactoryTest extends TestCase
         ]);
     }
 
-    public function testRaisesExceptionWhenDigestConfiguredAndNoDomainsPresent()
+    public function testRaisesExceptionWhenDigestConfiguredAndNoDomainsPresent(): void
     {
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('digest_domains');
@@ -79,7 +79,7 @@ class HttpAdapterFactoryTest extends TestCase
         ]);
     }
 
-    public function testRaisesExceptionWhenDigestConfiguredAndNoNoncePresent()
+    public function testRaisesExceptionWhenDigestConfiguredAndNoNoncePresent(): void
     {
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('digest_domains');
@@ -132,7 +132,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getDigestResolver());
     }
 
-    public function testCanReturnBasicAdapterWithApacheResolver()
+    public function testCanReturnBasicAdapterWithApacheResolver(): void
     {
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes' => ['basic'],
@@ -145,7 +145,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getDigestResolver());
     }
 
-    public function testCanReturnDigestAdapterWithFileResolver()
+    public function testCanReturnDigestAdapterWithFileResolver(): void
     {
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes' => ['digest'],
@@ -160,7 +160,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertInstanceOf(FileResolver::class, $adapter->getDigestResolver());
     }
 
-    public function testCanReturnCompoundAdapter()
+    public function testCanReturnCompoundAdapter(): void
     {
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes' => ['basic', 'digest'],
@@ -176,7 +176,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertInstanceOf(FileResolver::class, $adapter->getDigestResolver());
     }
 
-    public function testCanReturnBasicAdapterWithCustomResolverFromServiceManager()
+    public function testCanReturnBasicAdapterWithCustomResolverFromServiceManager(): void
     {
         $keyForServiceManager = 'keyForServiceManager';
 
@@ -208,7 +208,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getDigestResolver());
     }
 
-    public function testCanReturnDigestAdapterWithCustomResolverFromServiceManager()
+    public function testCanReturnDigestAdapterWithCustomResolverFromServiceManager(): void
     {
         $keyForServiceManager = 'keyForServiceManager';
 
@@ -240,7 +240,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertSame($resolver, $adapter->getDigestResolver());
     }
 
-    public function testCanReturnAdapterWithNoResolversAndInvalidServiceManager()
+    public function testCanReturnAdapterWithNoResolversAndInvalidServiceManager(): void
     {
         $adapter = HttpAdapterFactory::factory([
             'accept_schemes'          => ['basic', 'digest'],
@@ -256,7 +256,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getDigestResolver());
     }
 
-    public function testCanReturnAdapterWithNoResolversAndInvalidResolverKeys()
+    public function testCanReturnAdapterWithNoResolversAndInvalidResolverKeys(): void
     {
         $serviceManager = $this->getMockBuilder(ServiceLocatorInterface::class)->getMock();
         $serviceManager->expects($this->never())->method('has');
@@ -275,7 +275,7 @@ class HttpAdapterFactoryTest extends TestCase
         $this->assertNull($adapter->getDigestResolver());
     }
 
-    public function testCanReturnAdapterWithNoResolversAndMissingServiceManagerEntries()
+    public function testCanReturnAdapterWithNoResolversAndMissingServiceManagerEntries(): void
     {
         $missingKeyForServiceManager = 'missingKeyForServiceManager';
 

--- a/test/Factory/NamedOAuth2ServerFactoryTest.php
+++ b/test/Factory/NamedOAuth2ServerFactoryTest.php
@@ -63,21 +63,21 @@ class NamedOAuth2ServerFactoryTest extends TestCase
         return $services;
     }
 
-    public function testCallingReturnedFactoryMultipleTimesWithNoArgumentReturnsSameServerInstance()
+    public function testCallingReturnedFactoryMultipleTimesWithNoArgumentReturnsSameServerInstance(): void
     {
         $factory = $this->factory->__invoke($this->services, 'NamedOAuth2Server');
         $server  = $factory();
         $this->assertSame($server, $factory());
     }
 
-    public function testCallingReturnedFactoryMultipleTimesWithSameArgumentReturnsSameServerInstance()
+    public function testCallingReturnedFactoryMultipleTimesWithSameArgumentReturnsSameServerInstance(): void
     {
         $factory = $this->factory->__invoke($this->services, 'NamedOAuth2Server');
         $server  = $factory('test');
         $this->assertSame($server, $factory('test'));
     }
 
-    public function testCallingReturnedFactoryMultipleTimesWithDifferentArgumentsReturnsDifferentInstances()
+    public function testCallingReturnedFactoryMultipleTimesWithDifferentArgumentsReturnsDifferentInstances(): void
     {
         $factory = $this->factory->__invoke($this->services, 'NamedOAuth2Server');
         $server  = $factory('test');
@@ -85,7 +85,7 @@ class NamedOAuth2ServerFactoryTest extends TestCase
         $this->assertNotSame($server, $factory('test2'));
     }
 
-    public function testCallingReturnedFactoryWithUnrecognizedArgumentReturnsApplicationWideInstance()
+    public function testCallingReturnedFactoryWithUnrecognizedArgumentReturnsApplicationWideInstance(): void
     {
         $factory = $this->factory->__invoke($this->services, 'NamedOAuth2Server');
         $server  = $factory();

--- a/test/Factory/OAuth2ServerFactoryTest.php
+++ b/test/Factory/OAuth2ServerFactoryTest.php
@@ -45,7 +45,7 @@ class OAuth2ServerFactoryTest extends TestCase
         return $services;
     }
 
-    public function testRaisesExceptionIfAdapterIsMissing()
+    public function testRaisesExceptionIfAdapterIsMissing(): void
     {
         $services = $this->mockConfig(new ServiceManager());
         $config   = [
@@ -58,7 +58,7 @@ class OAuth2ServerFactoryTest extends TestCase
         OAuth2ServerFactory::factory($config, $services);
     }
 
-    public function testRaisesExceptionCreatingPdoBackedServerIfDsnIsMissing()
+    public function testRaisesExceptionCreatingPdoBackedServerIfDsnIsMissing(): void
     {
         $services = $this->mockConfig(new ServiceManager());
         $config   = [
@@ -73,7 +73,7 @@ class OAuth2ServerFactoryTest extends TestCase
         OAuth2ServerFactory::factory($config, $services);
     }
 
-    public function testCanCreatePdoAdapterBackedServer()
+    public function testCanCreatePdoAdapterBackedServer(): void
     {
         $services = $this->mockConfig(new ServiceManager());
         $config   = [
@@ -84,7 +84,7 @@ class OAuth2ServerFactoryTest extends TestCase
         $this->assertInstanceOf(OAuth2Server::class, $server);
     }
 
-    public function testCanCreateMongoBackedServerUsingMongoFromServices()
+    public function testCanCreateMongoBackedServerUsingMongoFromServices(): void
     {
         if (! class_exists(MongoDB::class)) {
             $this->markTestSkipped('Mongo extension is required for this test');
@@ -104,7 +104,7 @@ class OAuth2ServerFactoryTest extends TestCase
         $this->assertInstanceOf(OAuth2Server::class, $server);
     }
 
-    public function testRaisesExceptionCreatingMongoBackedServerIfDatabaseIsMissing()
+    public function testRaisesExceptionCreatingMongoBackedServerIfDatabaseIsMissing(): void
     {
         $services = $this->mockConfig(new ServiceManager());
         $config   = [
@@ -114,10 +114,10 @@ class OAuth2ServerFactoryTest extends TestCase
         $this->expectException(ServiceNotCreatedException::class);
         $this->expectExceptionMessage('database');
 
-        $server = OAuth2ServerFactory::factory($config, $services);
+        OAuth2ServerFactory::factory($config, $services);
     }
 
-    public function testCanCreateMongoAdapterBackedServer()
+    public function testCanCreateMongoAdapterBackedServer(): void
     {
         if (! class_exists(MongoDB::class)) {
             $this->markTestSkipped('Mongo extension is required for this test');
@@ -224,7 +224,7 @@ class OAuth2ServerFactoryTest extends TestCase
         }
     }
 
-    public function testAllowsUsingOpenIDConnectGrantTypeViaConfiguration()
+    public function testAllowsUsingOpenIDConnectGrantTypeViaConfiguration(): void
     {
         $options = $this->getOAuth2Options();
         $options['api-tools-oauth2']['options']['use_openid_connect'] = true;

--- a/test/Identity/AuthenticatedIdentityTest.php
+++ b/test/Identity/AuthenticatedIdentityTest.php
@@ -18,29 +18,29 @@ class AuthenticatedIdentityTest extends TestCase
         $this->identity     = new AuthenticatedIdentity($this->authIdentity);
     }
 
-    public function testAuthenticatedIsAnIdentityType()
+    public function testAuthenticatedIsAnIdentityType(): void
     {
         $this->assertInstanceOf(IdentityInterface::class, $this->identity);
     }
 
-    public function testAuthenticatedImplementsAclRole()
+    public function testAuthenticatedImplementsAclRole(): void
     {
         $this->assertInstanceOf(AclRoleInterface::class, $this->identity);
     }
 
-    public function testAuthenticatedImplementsRbacRole()
+    public function testAuthenticatedImplementsRbacRole(): void
     {
         $this->assertInstanceOf(RbacRoleInterface::class, $this->identity);
     }
 
-    public function testAuthenticatedAllowsSettingName()
+    public function testAuthenticatedAllowsSettingName(): void
     {
         $this->identity->setName($this->authIdentity->name);
         $this->assertEquals($this->authIdentity->name, $this->identity->getName());
         $this->assertEquals($this->authIdentity->name, $this->identity->getRoleId());
     }
 
-    public function testAuthenticatedComposesAuthenticatedIdentity()
+    public function testAuthenticatedComposesAuthenticatedIdentity(): void
     {
         $this->assertSame($this->authIdentity, $this->identity->getAuthenticationIdentity());
     }

--- a/test/Identity/GuestIdentityTest.php
+++ b/test/Identity/GuestIdentityTest.php
@@ -15,32 +15,32 @@ class GuestIdentityTest extends TestCase
         $this->identity = new GuestIdentity();
     }
 
-    public function testGuestIsAnIdentityType()
+    public function testGuestIsAnIdentityType(): void
     {
         $this->assertInstanceOf(IdentityInterface::class, $this->identity);
     }
 
-    public function testGuestImplementsAclRole()
+    public function testGuestImplementsAclRole(): void
     {
         $this->assertInstanceOf(AclRoleInterface::class, $this->identity);
     }
 
-    public function testGuestImplementsRbacRole()
+    public function testGuestImplementsRbacRole(): void
     {
         $this->assertInstanceOf(RbacRoleInterface::class, $this->identity);
     }
 
-    public function testGuestRoleIdIsGuest()
+    public function testGuestRoleIdIsGuest(): void
     {
         $this->assertEquals('guest', $this->identity->getRoleId());
     }
 
-    public function testGuestRoleNameIsGuest()
+    public function testGuestRoleNameIsGuest(): void
     {
         $this->assertEquals('guest', $this->identity->getName());
     }
 
-    public function testGuestDoesNotComposeAuthenticationIdentity()
+    public function testGuestDoesNotComposeAuthenticationIdentity(): void
     {
         $this->assertNull($this->identity->getAuthenticationIdentity());
     }

--- a/test/Identity/IdentityPluginTest.php
+++ b/test/Identity/IdentityPluginTest.php
@@ -26,18 +26,18 @@ class IdentityPluginTest extends TestCase
         $this->plugin->setController($controller);
     }
 
-    public function testMissingIdentityParamInEventCausesPluginToYieldGuestIdentity()
+    public function testMissingIdentityParamInEventCausesPluginToYieldGuestIdentity(): void
     {
         $this->assertInstanceOf(GuestIdentity::class, $this->plugin->__invoke());
     }
 
-    public function testInvalidTypeInEventIdentityParamCausesPluginToYieldGuestIdentity()
+    public function testInvalidTypeInEventIdentityParamCausesPluginToYieldGuestIdentity(): void
     {
         $this->event->setParam('Laminas\ApiTools\MvcAuth\Identity', (object) ['foo' => 'bar']);
         $this->assertInstanceOf(GuestIdentity::class, $this->plugin->__invoke());
     }
 
-    public function testValidIdentityInEventIsReturnedByPlugin()
+    public function testValidIdentityInEventIsReturnedByPlugin(): void
     {
         $identity = new AuthenticatedIdentity('mwop');
         $this->event->setParam('Laminas\ApiTools\MvcAuth\Identity', $identity);

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -55,7 +55,7 @@ class ModuleTest extends TestCase
         return new ServiceManager($servicesConfig);
     }
 
-    public function testOnBootstrapReturnsEarlyForNonHttpEvents()
+    public function testOnBootstrapReturnsEarlyForNonHttpEvents(): void
     {
         $mvcEvent = $this->prophesize(MvcEvent::class);
         $module   = new Module();

--- a/test/MvcAuthEventTest.php
+++ b/test/MvcAuthEventTest.php
@@ -21,19 +21,19 @@ class MvcAuthEventTest extends TestCase
         $this->mvcAuthEvent = new MvcAuthEvent($mvcEvent, new AuthenticationService(), new Acl());
     }
 
-    public function testGetAuthenticationService()
+    public function testGetAuthenticationService(): void
     {
         $this->assertInstanceOf(AuthenticationService::class, $this->mvcAuthEvent->getAuthenticationService());
     }
 
-    public function testHasAuthenticationResult()
+    public function testHasAuthenticationResult(): void
     {
         $this->assertFalse($this->mvcAuthEvent->hasAuthenticationResult());
         $this->mvcAuthEvent->setAuthenticationResult(new Result('success', 'foobar'));
         $this->assertTrue($this->mvcAuthEvent->hasAuthenticationResult());
     }
 
-    public function testSetAuthenticationResult()
+    public function testSetAuthenticationResult(): void
     {
         $this->assertSame(
             $this->mvcAuthEvent,
@@ -41,34 +41,34 @@ class MvcAuthEventTest extends TestCase
         );
     }
 
-    public function testGetAuthenticationResult()
+    public function testGetAuthenticationResult(): void
     {
         $this->mvcAuthEvent->setAuthenticationResult(new Result('success', 'foobar'));
         $this->assertInstanceOf(Result::class, $this->mvcAuthEvent->getAuthenticationResult());
     }
 
-    public function testGetAuthorizationService()
+    public function testGetAuthorizationService(): void
     {
         $this->assertInstanceOf(Acl::class, $this->mvcAuthEvent->getAuthorizationService());
     }
 
-    public function testGetMvcEvent()
+    public function testGetMvcEvent(): void
     {
         $this->assertInstanceOf(MvcEvent::class, $this->mvcAuthEvent->getMvcEvent());
     }
 
-    public function testSetIdentity()
+    public function testSetIdentity(): void
     {
         $this->assertSame($this->mvcAuthEvent, $this->mvcAuthEvent->setIdentity(new GuestIdentity()));
     }
 
-    public function testGetIdentity()
+    public function testGetIdentity(): void
     {
         $this->mvcAuthEvent->setIdentity($i = new GuestIdentity());
         $this->assertSame($i, $this->mvcAuthEvent->getIdentity());
     }
 
-    public function testResourceStringIsNullByDefault()
+    public function testResourceStringIsNullByDefault(): void
     {
         $this->assertNull($this->mvcAuthEvent->getResource());
     }
@@ -76,13 +76,13 @@ class MvcAuthEventTest extends TestCase
     /**
      * @depends testResourceStringIsNullByDefault
      */
-    public function testResourceStringIsMutable()
+    public function testResourceStringIsMutable(): void
     {
         $this->mvcAuthEvent->setResource('foo');
         $this->assertEquals('foo', $this->mvcAuthEvent->getResource());
     }
 
-    public function testAuthorizedFlagIsFalseByDefault()
+    public function testAuthorizedFlagIsFalseByDefault(): void
     {
         $this->assertFalse($this->mvcAuthEvent->isAuthorized());
     }
@@ -90,7 +90,7 @@ class MvcAuthEventTest extends TestCase
     /**
      * @depends testAuthorizedFlagIsFalseByDefault
      */
-    public function testAuthorizedFlagIsMutable()
+    public function testAuthorizedFlagIsMutable(): void
     {
         $this->mvcAuthEvent->setIsAuthorized(true);
         $this->assertTrue($this->mvcAuthEvent->isAuthorized());

--- a/test/MvcRouteListenerTest.php
+++ b/test/MvcRouteListenerTest.php
@@ -46,7 +46,7 @@ class MvcRouteListenerTest extends TestCase
         );
     }
 
-    public function testRegistersAuthenticationListenerOnExpectedPriority()
+    public function testRegistersAuthenticationListenerOnExpectedPriority(): void
     {
         $this->listener->attach($this->events);
         $this->assertListenerAtPriority(
@@ -57,7 +57,7 @@ class MvcRouteListenerTest extends TestCase
         );
     }
 
-    public function testRegistersPostAuthenticationListenerOnExpectedPriority()
+    public function testRegistersPostAuthenticationListenerOnExpectedPriority(): void
     {
         $this->listener->attach($this->events);
         $this->assertListenerAtPriority(
@@ -68,7 +68,7 @@ class MvcRouteListenerTest extends TestCase
         );
     }
 
-    public function testRegistersAuthorizationListenerOnExpectedPriority()
+    public function testRegistersAuthorizationListenerOnExpectedPriority(): void
     {
         $this->listener->attach($this->events);
         $this->assertListenerAtPriority(
@@ -79,7 +79,7 @@ class MvcRouteListenerTest extends TestCase
         );
     }
 
-    public function testRegistersPostAuthorizationListenerOnExpectedPriority()
+    public function testRegistersPostAuthorizationListenerOnExpectedPriority(): void
     {
         $this->listener->attach($this->events);
         $this->assertListenerAtPriority(


### PR DESCRIPTION
This patch adds Psalm integration for the CI workflow. It does so by:

- Adding Psalm and its PHPUnit plugin as dev requirements
- Adding Psalm configuration
- Applying automated fixes as suggested by Psalm

Fixes #28
