### PR TITLE
Fixed wrong typing in `AuthenticatedIdentity` docBlocks

### DIFF
--- a/src/Identity/AuthenticatedIdentity.php
+++ b/src/Identity/AuthenticatedIdentity.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Laminas\ApiTools\MvcAuth\Identity;
 
 use Laminas\Permissions\Rbac\Role;
-use Laminas\Permissions\Rbac\RoleInterface;
 
 class AuthenticatedIdentity extends Role implements IdentityInterface
 {
-    /** @var string|RoleInterface */
+    /** @var string|IdentityInterface */
     protected $identity;
 
-    /** @param string|RoleInterface $identity */
+    /** @param string|IdentityInterface $identity */
     public function __construct($identity)
     {
         $this->identity = $identity;
@@ -24,7 +23,7 @@ class AuthenticatedIdentity extends Role implements IdentityInterface
         return $this->name;
     }
 
-    /** @return string|RoleInterface */
+    /** @return string|IdentityInterface */
     public function getAuthenticationIdentity()
     {
         return $this->identity;


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

As the class currently already implements `IdentityInterface` (that in turn extends the RoleInterfaces from Rbac **and** Acl) and the class thus already possesses a method `getRoleId()` (as in the **Acl** RoleInterface), it seems to me that the concerned doc blocks should also use `IdentityInterface` instead of the Rbac RoleInterface.

The current version leads to errors in PHPStan (starting at `--level 5` with v0.12.99) when doing :
```
new AuthenticatedIdentity($user); // $user implements Acl RoleInterface
```

Seems to have been introduced some months ago with PHP 8.0 support.
Concerned branches are `1.6.x` and `1.7.x`. `1.5.x` doesn't have comments.

Thanks and best regards,
Pascal