### PR TITLE
fixed wrong type for identity property

### DIFF
--- a/src/Identity/AuthenticatedIdentity.php
+++ b/src/Identity/AuthenticatedIdentity.php
@@ -8,10 +8,10 @@ use Laminas\Permissions\Rbac\Role;
 
 class AuthenticatedIdentity extends Role implements IdentityInterface
 {
-    /** @var string|IdentityInterface */
+    /** @var mixed */
     protected $identity;
 
-    /** @param string|IdentityInterface $identity */
+    /** @param mixed $identity */
     public function __construct($identity)
     {
         $this->identity = $identity;
@@ -23,7 +23,7 @@ class AuthenticatedIdentity extends Role implements IdentityInterface
         return $this->name;
     }
 
-    /** @return string|IdentityInterface */
+    /** @return mixed */
     public function getAuthenticationIdentity()
     {
         return $this->identity;


### PR DESCRIPTION
Signed-off-by: Pascal Paulis <ppaulis@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The `$identity` in `AuthenticatedIdentity` has been wrongly typed (by me) to `IdentityInterface`. Before the last PR, `$identity` was a `RoleInterface` (which was also not correct):

https://github.com/laminas-api-tools/api-tools-mvc-auth/commit/8428fb4e0458382a575655669ad58a93b5f27754

I think the correct way is to change `$identity` to `mixed`, so that developers can use any type of identity class/string/...

The current version causes problems with static analyzers (e.g. PHPStan).